### PR TITLE
Make a single `Radium` trait which is generic over the base type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ include = ["src/**/*", "Cargo.toml", "README.md"]
 edition = "2018"
 
 [dependencies]
+
+[dev-dependencies]
+static_assertions = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "radium"
-version = "0.1.1"
-authors = ["Nika Layzell <nika@thelayzells.com>"]
+version = "0.2.0"
+authors = [
+    "Nika Layzell <nika@thelayzells.com>",
+    "myrrlyn <self@myrrlyn.dev>"
+]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/mystor/radium"
@@ -14,6 +17,5 @@ categories = ["concurrency", "no-std"]
 include = ["src/**/*", "Cargo.toml", "README.md"]
 
 edition = "2018"
-
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -3,14 +3,13 @@
 [![Latest Version](https://img.shields.io/crates/v/radium.svg)](https://crates.io/crates/radium)
 [![Documentation](https://docs.rs/radium/badge.svg)](https://docs.rs/radium)
 
-`radium` provides a series of helper traits providing a uniform API for
-interacting with both atomic types like
-[`AtomicUsize`](core::sync::atomic::AtomicUsize), and non-atomic types like
-[`Cell<usize>`](core::cell::Cell).
+`radium` provides a helper trait with a uniform API for interacting with both
+atomic types like [`AtomicUsize`](core::sync::atomic::AtomicUsize), and
+non-atomic types like [`Cell<usize>`](core::cell::Cell).
 
 This crate is `#![no_std]`-compatible, and uses no non-core types.
 
-For more details, see each trait's documentation.
+For more details, see the trait's documentation.
 
 ---
 

--- a/examples/schroedinger.rs
+++ b/examples/schroedinger.rs
@@ -6,12 +6,7 @@
 //! a unified trait interface for a cell and an atom of the same underlying
 //! type.
 
-use radium::{
-    // Import this for load/store operations
-    Radium,
-    // Import this for add/sub operations
-    RadiumInteger,
-};
+use radium::Radium;
 
 use std::{
     cell::Cell,
@@ -21,7 +16,7 @@ use std::{
 };
 
 /// Operates on a value, which might or might not be atomic.
-fn routine<R: RadiumInteger<u64>>(obj: &R, ident: usize) {
+fn routine<R: Radium<u64>>(obj: &R, ident: usize) {
     println!(
         "Entry {} observes value: {}",
         ident,

--- a/examples/schroedinger.rs
+++ b/examples/schroedinger.rs
@@ -1,0 +1,58 @@
+//! This is a small example which demonstrates how a function which does not
+//! care about atomicity can be used to operate on a value.
+//!
+//! The context which *uses* such a function must still care about atomicity;
+//! `radium` does not suddenly permit `Cell` to cross threads. It just provides
+//! a unified trait interface for a cell and an atom of the same underlying
+//! type.
+
+use radium::{
+	//  Import this for load/store operations
+    Radium,
+	//  Import this for add/sub operations
+    RadiumInteger,
+};
+
+use std::{
+    cell::Cell,
+    sync::atomic::{
+        AtomicU64,
+        Ordering,
+    },
+    thread,
+    time::Duration,
+};
+
+/// Operates on a value, which might or might not be atomic.
+fn routine<R: RadiumInteger<u64>>(obj: &R, ident: usize) {
+    println!("Entry {} observes value: {}", ident, obj.load(Ordering::Relaxed));
+    obj.fetch_add(1, Ordering::Relaxed);
+    println!("Middle {} observes value: {}", ident, obj.load(Ordering::Relaxed));
+    thread::sleep(Duration::from_millis(obj.load(Ordering::Relaxed) * 10));
+    obj.fetch_sub(1, Ordering::Relaxed);
+    println!("Exit {} observes value: {}", ident, obj.load(Ordering::Relaxed));
+}
+
+/// Single value which will be contended by multiple threads
+static HOT: AtomicU64 = AtomicU64::new(0);
+
+fn main() {
+    //  This cannot cross a thread, so it is only accessed without contention in
+    //  an ordered call sequence.
+    let cold = Cell::new(0u64);
+
+    routine(&cold, 0);
+    let one = thread::spawn(move || {
+        routine(&HOT, 1);
+    });
+    let two = thread::spawn(move || {
+        routine(&HOT, 2);
+    });
+    routine(&cold, 3);
+
+    let _ = one.join();
+    let _ = two.join();
+
+    assert_eq!(HOT.load(Ordering::Relaxed), 0);
+    assert_eq!(cold.load(Ordering::Relaxed), 0);
+}

--- a/examples/schroedinger.rs
+++ b/examples/schroedinger.rs
@@ -7,30 +7,41 @@
 //! type.
 
 use radium::{
-	//  Import this for load/store operations
+    // Import this for load/store operations
     Radium,
-	//  Import this for add/sub operations
+    // Import this for add/sub operations
     RadiumInteger,
 };
 
 use std::{
     cell::Cell,
-    sync::atomic::{
-        AtomicU64,
-        Ordering,
-    },
+    sync::atomic::{AtomicU64, Ordering},
     thread,
     time::Duration,
 };
 
 /// Operates on a value, which might or might not be atomic.
 fn routine<R: RadiumInteger<u64>>(obj: &R, ident: usize) {
-    println!("Entry {} observes value: {}", ident, obj.load(Ordering::Relaxed));
-    obj.fetch_add(1, Ordering::Relaxed);
-    println!("Middle {} observes value: {}", ident, obj.load(Ordering::Relaxed));
+    println!(
+        "Entry {} observes value: {}",
+        ident,
+        obj.load(Ordering::Relaxed)
+    );
+    let added = obj.fetch_add(1, Ordering::Relaxed);
+    println!("Middle {} observes fetched value: {}", ident, added);
+    println!(
+        "Middle {} observes loaded value:  {}",
+        ident,
+        obj.load(Ordering::Relaxed)
+    );
     thread::sleep(Duration::from_millis(obj.load(Ordering::Relaxed) * 10));
-    obj.fetch_sub(1, Ordering::Relaxed);
-    println!("Exit {} observes value: {}", ident, obj.load(Ordering::Relaxed));
+    let subbed = obj.fetch_sub(1, Ordering::Relaxed);
+    println!("Exit {} observes fetched value: {}", ident, subbed);
+    println!(
+        "Exit {} observes loaded value:  {}",
+        ident,
+        obj.load(Ordering::Relaxed)
+    );
 }
 
 /// Single value which will be contended by multiple threads

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,506 +26,9 @@
 
 use core::cell::Cell;
 use core::sync::atomic::{
-    self,
-    fence, AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize, AtomicPtr,
-    AtomicU16, AtomicU32, AtomicU64, AtomicU8, AtomicUsize, Ordering,
+    self, AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize, AtomicPtr, AtomicU16,
+    AtomicU32, AtomicU64, AtomicU8, AtomicUsize, Ordering,
 };
-
-/// Hacky internal helper macro for using macros to build up doc comments.
-macro_rules! doc_comment {
-    ($doc:expr, $($rest:tt)*) => {
-        #[doc = $doc]
-        $($rest)*
-    };
-}
-
-/// Helper macro for declaring the body of a trait given the set of methods
-/// which should be present (base, binary, or int).
-macro_rules! trait_decl {
-    (base: $T:ty, $s_atomic:expr) => {
-        /// Creates a new value of this type.
-        fn new(v: $T) -> Self;
-
-        /// If the underlying value is atomic, calls [`fence`] with the given
-        /// [`Ordering`]. Otherwise, does nothing.
-        ///
-        /// See also: [`fence`]
-        fn fence(order: Ordering);
-
-        /// Returns a mutable reference to the underlying value.
-        ///
-        /// This is safe because the mutable reference guarantees that no other
-        /// references exist to this value.
-        fn get_mut(&mut self) -> &mut $T;
-
-        /// Consumes and returns the contained value.
-        ///
-        /// This is safe as passing by value ensures no other references exist.
-        fn into_inner(self) -> $T;
-
-        doc_comment! {
-            concat!("Load a value from this object.
-
-Ordering arguments are ignored by non-atomic types.
-
-See also: [`", $s_atomic, "::load`]"),
-            fn load(&self, order: Ordering) -> $T;
-        }
-
-        doc_comment! {
-            concat!("Store a value in this object.
-
-Ordering arguments are ignored by non-atomic types.
-
-See also: [`", $s_atomic, "::store`]"),
-            fn store(&self, val: $T, order: Ordering);
-        }
-
-        doc_comment! {
-            concat!("Swap with the value stored in this object.
-
-Ordering arguments are ignored by non-atomic types.
-
-See also: [`", $s_atomic, "::swap`]"),
-            fn swap(&self, val: $T, order: Ordering) -> $T;
-        }
-
-        doc_comment! {
-            concat!("Stores a value into this object if the current value is the
-same as the `current` value.
-
-The return value is always the previous value. If it is equal to `current`, then
-the value was updated.
-
-Ordering arguments are ignored by non-atomic types.
-
-See also: [`", $s_atomic, "::compare_and_swap`]"),
-            fn compare_and_swap(&self, current: $T, new: $T, order: Ordering) -> $T;
-        }
-
-        doc_comment! {
-            concat!("Stores a value into this object if the current value is the
-same as the `current` value.
-
-The return value is a result indicating whether the new value was written and
-containing the previous value. On success this value is guaranteed to be equal
-to `current`.
-
-Ordering arguments are ignored by non-atomic types.
-
-See also: [`", $s_atomic, "::compare_exchange`]"),
-            fn compare_exchange(
-                &self,
-                current: $T,
-                new: $T,
-                success: Ordering,
-                failure: Ordering,
-            ) -> Result<$T, $T>;
-        }
-
-        doc_comment! {
-            concat!("Stores a value into this object if the current value is the
-same as the `current` value.
-
-Unlike `compare_exchange`, this function is allowed to spuriously fail even when
-the comparison succeeds, which can result in more efficient code on some
-platforms. The return value is a result indicating whether the new value was
-written and containing the previous value.
-
-Ordering arguments are ignored by non-atomic types.
-
-See also: [`", $s_atomic, "::compare_exchange_weak`]"),
-            fn compare_exchange_weak(
-                &self,
-                current: $T,
-                new: $T,
-                success: Ordering,
-                failure: Ordering,
-            ) -> Result<$T, $T>;
-        }
-    };
-
-    (binary: $T:ty, $s_atomic:expr) => {
-        trait_decl!(base: $T, $s_atomic);
-
-        doc_comment! {
-            concat!("Performs a bitwise \"and\" on the current value and the
-argument `val`, snd sets the new value to the result.
-
-Returns the previous value.
-
-Ordering arguments are ignored by non-atomic types.
-
-See also: [`", $s_atomic, "::fetch_and`]"),
-            fn fetch_and(&self, val: $T, order: Ordering) -> $T;
-        }
-
-        doc_comment! {
-            concat!("Performs a bitwise \"nand\" on the current value and the
-argument `val`, snd sets the new value to the result.
-
-Returns the previous value.
-
-Ordering arguments are ignored by non-atomic types.
-
-See also: [`", $s_atomic, "::fetch_nand`]"),
-            fn fetch_nand(&self, val: $T, order: Ordering) -> $T;
-        }
-
-        doc_comment! {
-            concat!("Performs a bitwise \"or\" on the current value and the
-argument `val`, snd sets the new value to the result.
-
-Returns the previous value.
-
-Ordering arguments are ignored by non-atomic types.
-
-See also: [`", $s_atomic, "::fetch_or`]"),
-            fn fetch_or(&self, val: $T, order: Ordering) -> $T;
-        }
-
-        doc_comment! {
-            concat!("Performs a bitwise \"xor\" on the current value and the
-argument `val`, snd sets the new value to the result.
-
-Returns the previous value.
-
-Ordering arguments are ignored by non-atomic types.
-
-See also: [`", $s_atomic, "::fetch_xor`]"),
-            fn fetch_xor(&self, val: $T, order: Ordering) -> $T;
-        }
-    };
-
-    (int: $T:ty, $s_atomic:expr) => {
-        trait_decl!(binary: $T, $s_atomic);
-
-        doc_comment! {
-            concat!("Increments the current value by `val`, wrapping on overflow.
-
-Returns the previous value.
-
-Ordering arguments are ignored by non-atomic types.
-
-See also: [`", $s_atomic, "::fetch_add`]"),
-            fn fetch_add(&self, val: $T, order: Ordering) -> $T;
-        }
-
-        doc_comment! {
-            concat!("Decrements the current value by `val`, wrapping on overflow.
-
-Returns the previous value.
-
-Ordering arguments are ignored by non-atomic types.
-
-See also: [`", $s_atomic, "::fetch_sub`]"),
-            fn fetch_sub(&self, val: $T, order: Ordering) -> $T;
-        }
-    };
-}
-
-/// Helper macro for declaring the atomic impl of a trait given the set of
-/// methods which should be present (base, binary, or int).
-macro_rules! atomic_impl {
-    (base: $T:ty) => {
-        #[inline]
-        fn new(v: $T) -> Self {
-            Self::new(v)
-        }
-
-        #[inline]
-        fn fence(order: Ordering) {
-            fence(order)
-        }
-
-        #[inline]
-        fn get_mut(&mut self) -> &mut $T {
-            self.get_mut()
-        }
-
-        #[inline]
-        fn into_inner(self) -> $T {
-            self.into_inner()
-        }
-
-        #[inline]
-        fn load(&self, order: Ordering) -> $T {
-            self.load(order)
-        }
-
-        #[inline]
-        fn store(&self, val: $T, order: Ordering) {
-            self.store(val, order)
-        }
-
-        #[inline]
-        fn swap(&self, val: $T, order: Ordering) -> $T {
-            self.swap(val, order)
-        }
-
-        #[inline]
-        fn compare_and_swap(&self, current: $T, new: $T, order: Ordering) -> $T {
-            self.compare_and_swap(current, new, order)
-        }
-
-        #[inline]
-        fn compare_exchange(
-            &self,
-            current: $T,
-            new: $T,
-            success: Ordering,
-            failure: Ordering,
-        ) -> Result<$T, $T> {
-            self.compare_exchange(current, new, success, failure)
-        }
-
-        #[inline]
-        fn compare_exchange_weak(
-            &self,
-            current: $T,
-            new: $T,
-            success: Ordering,
-            failure: Ordering,
-        ) -> Result<$T, $T> {
-            self.compare_exchange_weak(current, new, success, failure)
-        }
-    };
-
-    (binary: $T:ty) => {
-        atomic_impl!(base: $T);
-
-        #[inline]
-        fn fetch_and(&self, val: $T, order: Ordering) -> $T {
-            self.fetch_and(val, order)
-        }
-
-        #[inline]
-        fn fetch_nand(&self, val: $T, order: Ordering) -> $T {
-            self.fetch_nand(val, order)
-        }
-
-        #[inline]
-        fn fetch_or(&self, val: $T, order: Ordering) -> $T {
-            self.fetch_or(val, order)
-        }
-
-        #[inline]
-        fn fetch_xor(&self, val: $T, order: Ordering) -> $T {
-            self.fetch_xor(val, order)
-        }
-    };
-
-    (int: $T:ty) => {
-        atomic_impl!(binary: $T);
-
-        #[inline]
-        fn fetch_add(&self, val: $T, order: Ordering) -> $T {
-            self.fetch_add(val, order)
-        }
-
-        #[inline]
-        fn fetch_sub(&self, val: $T, order: Ordering) -> $T {
-            self.fetch_sub(val, order)
-        }
-    }
-}
-
-/// Helper macro for declaring the cell impl of a trait given the set of methods
-/// which should be present (base, binary, or int).
-macro_rules! cell_impl {
-    (base: $T:ty) => {
-        #[inline]
-        fn new(v: $T) -> Self {
-            Cell::new(v)
-        }
-
-        #[inline]
-        fn fence(_order: Ordering) {
-            // no-op
-        }
-
-        #[inline]
-        fn get_mut(&mut self) -> &mut $T {
-            self.get_mut()
-        }
-
-        #[inline]
-        fn into_inner(self) -> $T {
-            self.into_inner()
-        }
-
-        #[inline]
-        fn load(&self, _order: Ordering) -> $T {
-            self.get()
-        }
-
-        #[inline]
-        fn store(&self, val: $T, _order: Ordering) {
-            self.set(val)
-        }
-
-        #[inline]
-        fn swap(&self, val: $T, _order: Ordering) -> $T {
-            self.replace(val)
-        }
-
-        #[inline]
-        fn compare_and_swap(&self, current: $T, new: $T, _order: Ordering) -> $T {
-            if self.get() == current {
-                self.replace(new)
-            } else {
-                self.get()
-            }
-        }
-
-        #[inline]
-        fn compare_exchange(
-            &self,
-            current: $T,
-            new: $T,
-            _success: Ordering,
-            _failure: Ordering,
-        ) -> Result<$T, $T> {
-            if self.get() == current {
-                Ok(self.replace(new))
-            } else {
-                Err(self.get())
-            }
-        }
-
-        #[inline]
-        fn compare_exchange_weak(
-            &self,
-            current: $T,
-            new: $T,
-            _success: Ordering,
-            _failure: Ordering,
-        ) -> Result<$T, $T> {
-            if self.get() == current {
-                Ok(self.replace(new))
-            } else {
-                Err(self.get())
-            }
-        }
-    };
-
-    (binary: $T:ty) => {
-        cell_impl!(base: $T);
-
-        #[inline]
-        fn fetch_and(&self, val: $T, _order: Ordering) -> $T {
-            self.replace(self.get() & val)
-        }
-
-        #[inline]
-        fn fetch_nand(&self, val: $T, _order: Ordering) -> $T {
-            self.replace(!(self.get() & val))
-        }
-
-        #[inline]
-        fn fetch_or(&self, val: $T, _order: Ordering) -> $T {
-            self.replace(self.get() | val)
-        }
-
-        #[inline]
-        fn fetch_xor(&self, val: $T, _order: Ordering) -> $T {
-            self.replace(self.get() ^ val)
-        }
-    };
-
-    (int: $T:ty) => {
-        cell_impl!(binary: $T);
-
-        #[inline]
-        fn fetch_add(&self, val: $T, _order: Ordering) -> $T {
-            self.replace(self.get().wrapping_add(val))
-        }
-
-        #[inline]
-        fn fetch_sub(&self, val: $T, _order: Ordering) -> $T {
-            self.replace(self.get().wrapping_sub(val))
-        }
-    }
-}
-
-macro_rules! radium_int {
-    ($Radium:ident, $Atomic:ty, $T:ty) => {
-        doc_comment! {
-            concat!("A maybe-atomic shared mutable [`", stringify!($T), "`].
-
-This trait is implemented by both [`", stringify!($Atomic), "`] and
-[`Cell<", stringify!($T), ">`](Cell), providing a consistent
-interface for interacting with the two types."),
-            #[deprecated(since = "0.2", note = "Use `Radium<T>` instead")]
-            pub trait $Radium {
-                trait_decl!(int: $T, stringify!($Atomic));
-            }
-        }
-
-        #[allow(deprecated)]
-        impl $Radium for $Atomic {
-            atomic_impl!(int: $T);
-        }
-
-        #[allow(deprecated)]
-        impl $Radium for Cell<$T> {
-            cell_impl!(int: $T);
-        }
-    };
-}
-
-radium_int!(RadiumI8, AtomicI8, i8);
-radium_int!(RadiumI16, AtomicI16, i16);
-radium_int!(RadiumI32, AtomicI32, i32);
-radium_int!(RadiumI64, AtomicI64, i64);
-radium_int!(RadiumIsize, AtomicIsize, isize);
-
-radium_int!(RadiumU8, AtomicU8, u8);
-radium_int!(RadiumU16, AtomicU16, u16);
-radium_int!(RadiumU32, AtomicU32, u32);
-radium_int!(RadiumU64, AtomicU64, u64);
-radium_int!(RadiumUsize, AtomicUsize, usize);
-
-/// A maybe-atomic shared mutable [`bool`].
-///
-/// This trait is implemented by both [`AtomicBool`] and [`Cell<bool>`](Cell),
-/// providing a consistent interface for interacting with the two types.
-#[deprecated(since = "0.2", note = "Prefer `Radium<bool>` instead")]
-pub trait RadiumBool {
-    trait_decl!(binary: bool, "AtomicBool");
-}
-
-#[allow(deprecated)]
-impl RadiumBool for AtomicBool {
-    atomic_impl!(binary: bool);
-}
-
-#[allow(deprecated)]
-impl RadiumBool for Cell<bool> {
-    cell_impl!(binary: bool);
-}
-
-/// A maybe-atomic shared mutable [`*mut T`].
-///
-/// This trait is implemented by both [`AtomicPtr<T>`](AtomicPtr) and
-/// [`Cell<*mut T>`](Cell), providing a consistent interface for interacting
-/// with the two types.
-///
-/// [`*mut T`]: https://doc.rust-lang.org/stable/std/primitive.pointer.html
-#[deprecated(since = "0.2", note = "Prefer `Radium<*mut T>` instead")]
-pub trait RadiumPtr<T> {
-    trait_decl!(base: *mut T, "AtomicPtr");
-}
-
-#[allow(deprecated)]
-impl<T> RadiumPtr<T> for AtomicPtr<T> {
-    atomic_impl!(base: *mut T);
-}
-
-#[allow(deprecated)]
-impl<T> RadiumPtr<T> for Cell<*mut T> {
-    cell_impl!(base: *mut T);
-}
 
 /// A maybe-atomic shared mutable fundamental type `T`.
 ///
@@ -568,25 +71,27 @@ pub trait Radium<Item> {
     ///
     /// Ordering values are ignored by non-atomic types.
     ///
-    /// See also: [`AtomicU8::load`].
+    /// See also: [`AtomicUsize::load`].
     ///
-    /// [`AtomicU8::load`]: core::sync::atomic::AtomicU8::load
+    /// [`AtomicUsize::load`]: core::sync::atomic::AtomicUsize::load
     fn load(&self, order: Ordering) -> Item;
 
     /// Store a value in this object.
     ///
     /// Ordering arguments are ignored by non-atomic types.
     ///
-    /// See also: [`AtomicU8::store`]: core::sync::atomic::AtomicU8::store
+    /// See also: [`AtomicUsize::store`].
+    ///
+    /// [`AtomicUsize::store`]: core::sync::atomic::AtomicUsize::store
     fn store(&self, value: Item, order: Ordering);
 
     /// Swap with the value stored in this object.
     ///
     /// Ordering arguments are ignored by non-atomic types.
     ///
-    /// See also: [`AtomicU8::swap`].
+    /// See also: [`AtomicUsize::swap`].
     ///
-    /// [`AtomicU8::swap`]: core::sync::atomic::AtomicU8::swap
+    /// [`AtomicUsize::swap`]: core::sync::atomic::AtomicUsize::swap
     fn swap(&self, value: Item, order: Ordering) -> Item;
 
     /// Stores a value into this object if the currently-stored value is the
@@ -597,15 +102,10 @@ pub trait Radium<Item> {
     ///
     /// Ordering arguments are ignored by non-atomic types.
     ///
-    /// See also: [`AtomicU8::compare_and_swap`].
+    /// See also: [`AtomicUsize::compare_and_swap`].
     ///
-    /// [`AtomicU8::compare_and_swap`]: core::sync::atomic::AtomicU8::compare_and_swap
-    fn compare_and_swap(
-        &self,
-        current: Item,
-        new: Item,
-        order: Ordering,
-    ) -> Item;
+    /// [`AtomicUsize::compare_and_swap`]: core::sync::atomic::AtomicUsize::compare_and_swap
+    fn compare_and_swap(&self, current: Item, new: Item, order: Ordering) -> Item;
 
     /// Stores a value into this object if the currently-stored value is the
     /// same as the `current` value.
@@ -616,9 +116,9 @@ pub trait Radium<Item> {
     ///
     /// Ordering arguments are ignored by non-atomic types.
     ///
-    /// See also: [`AtomicU8::compare_exchange`].
+    /// See also: [`AtomicUsize::compare_exchange`].
     ///
-    /// [`AtomicU8::compare_exchange`]: core::sync::atomic::AtomicU8::compare_exchange
+    /// [`AtomicUsize::compare_exchange`]: core::sync::atomic::AtomicUsize::compare_exchange
     fn compare_exchange(
         &self,
         current: Item,
@@ -638,9 +138,9 @@ pub trait Radium<Item> {
     ///
     /// Ordering arguments are ignored by non-atomic types.
     ///
-    /// See also: [`AtomicU8::compare_exchange_weak`].
+    /// See also: [`AtomicUsize::compare_exchange_weak`].
     ///
-    /// [`AtomicU8::compare_exchange_weak`]: core::sync::atomic::AtomicU8::compare_exchange_weak
+    /// [`AtomicUsize::compare_exchange_weak`]: core::sync::atomic::AtomicUsize::compare_exchange_weak
     fn compare_exchange_weak(
         &self,
         current: Item,
@@ -659,9 +159,9 @@ pub trait RadiumBits<Item>: Radium<Item> {
     ///
     /// Ordering arguments are ignored by non-atomic types.
     ///
-    /// See also: [`AtomicU8::fetch_and`].
+    /// See also: [`AtomicUsize::fetch_and`].
     ///
-    /// [`AtomicU8::fetch_and`]: core::sync::atomic::AtomicU8::fetch_and
+    /// [`AtomicUsize::fetch_and`]: core::sync::atomic::AtomicUsize::fetch_and
     fn fetch_and(&self, value: Item, order: Ordering) -> Item;
 
     /// Performs a bitwise "nand" on the currently-stored value and the argument
@@ -671,9 +171,9 @@ pub trait RadiumBits<Item>: Radium<Item> {
     ///
     /// Ordering arguments are ignored by non-atomic types.
     ///
-    /// See also: [`AtomicU8::fetch_nand`].
+    /// See also: [`AtomicUsize::fetch_nand`].
     ///
-    /// [`AtomicU8::fetch_nand`]: core::sync::atomic::AtomicU8::fetch_nand
+    /// [`AtomicUsize::fetch_nand`]: core::sync::atomic::AtomicUsize::fetch_nand
     fn fetch_nand(&self, value: Item, order: Ordering) -> Item;
 
     /// Performs a bitwise "or" on the currently-stored value and the argument
@@ -683,9 +183,9 @@ pub trait RadiumBits<Item>: Radium<Item> {
     ///
     /// Ordering arguments are ignored by non-atomic types.
     ///
-    /// See also: [`AtomicU8::fetch_or`].
+    /// See also: [`AtomicUsize::fetch_or`].
     ///
-    /// [`AtomicU8::fetch_or`]: core::sync::atomic::AtomicU8::fetch_or
+    /// [`AtomicUsize::fetch_or`]: core::sync::atomic::AtomicUsize::fetch_or
     fn fetch_or(&self, value: Item, order: Ordering) -> Item;
 
     /// Performs a bitwise "xor" on the currently-stored value and the argument
@@ -695,14 +195,18 @@ pub trait RadiumBits<Item>: Radium<Item> {
     ///
     /// Ordering arguments are ignored by non-atomic types.
     ///
-    /// See also: [`AtomicU8::fetch_xor`].
+    /// See also: [`AtomicUsize::fetch_xor`].
     ///
-    /// [`AtomicU8::fetch_xor`]: core::sync::atomic::AtomicU8::fetch_xor
+    /// [`AtomicUsize::fetch_xor`]: core::sync::atomic::AtomicUsize::fetch_xor
     fn fetch_xor(&self, value: Item, order: Ordering) -> Item;
 }
 
 /// Performs integer arithmetic on a maybe-atomic value.
-pub trait RadiumInteger<Item>: Radium<Item> {
+///
+/// All integer types implement `RadiumBits`, so `RadiumInteger` may specify
+/// `RadiumBits` as a supertrait, and users may specify `RadiumInteger` alone to
+/// access `RadiumBits` as well.
+pub trait RadiumInteger<Item>: RadiumBits<Item> {
     /// Adds `value` to the currently-stored value, wrapping on overflow, and
     /// stores the result in `self`.
     ///
@@ -710,9 +214,9 @@ pub trait RadiumInteger<Item>: Radium<Item> {
     ///
     /// Ordering arguments are ignored by non-atomic types.
     ///
-    /// See also: [`AtomicU8::fetch_add`].
+    /// See also: [`AtomicUsize::fetch_add`].
     ///
-    /// [`AtomicU8::fetch_add`]: core::sync::atomic::AtomicU8::fetch_add
+    /// [`AtomicUsize::fetch_add`]: core::sync::atomic::AtomicUsize::fetch_add
     fn fetch_add(&self, value: Item, order: Ordering) -> Item;
 
     /// Subtracts `value` from the currently-stored value, wrapping on
@@ -722,9 +226,9 @@ pub trait RadiumInteger<Item>: Radium<Item> {
     ///
     /// Ordering arguments are ignored by non-atomic types.
     ///
-    /// See also: [`AtomicU8::fetch_sub`].
+    /// See also: [`AtomicUsize::fetch_sub`].
     ///
-    /// [`AtomicU8::fetch_sub`]: core::sync::atomic::AtomicU8::fetch_sub
+    /// [`AtomicUsize::fetch_sub`]: core::sync::atomic::AtomicUsize::fetch_sub
     fn fetch_sub(&self, value: Item, order: Ordering) -> Item;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 //! `radium` provides a series of helper traits providing a uniform API for
 //! interacting with both atomic types like
-//! [`AtomicUsize`](core::sync::atomic::AtomicUsize), and non-atomic types like
-//! [`Cell<usize>`](core::cell::Cell).
+//! [`AtomicUsize`], and non-atomic types like [`Cell<T>`].
 //!
 //! This crate is `#![no_std]`-compatible, and uses no non-core types.
 //!
@@ -18,12 +17,16 @@
 //! > no but call the crate radium
 //! >
 //! > (since people didn't care that it was radioactive and used it in everything)
+//!
+//! [`AtomicUsize`]: core::sync::atomic::AtomicUsize
+//! [`Cell<T>`]: core::cell::Cell
 
 #![no_std]
 #![deny(unconditional_recursion)]
 
 use core::cell::Cell;
 use core::sync::atomic::{
+    self,
     fence, AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize, AtomicPtr,
     AtomicU16, AtomicU32, AtomicU64, AtomicU8, AtomicUsize, Ordering,
 };
@@ -395,10 +398,14 @@ macro_rules! cell_impl {
             &self,
             current: $T,
             new: $T,
-            success: Ordering,
-            failure: Ordering,
+            _success: Ordering,
+            _failure: Ordering,
         ) -> Result<$T, $T> {
-            self.compare_exchange(current, new, success, failure)
+            if self.get() == current {
+                Ok(self.replace(new))
+            } else {
+                Err(self.get())
+            }
         }
     };
 
@@ -449,15 +456,18 @@ macro_rules! radium_int {
 This trait is implemented by both [`", stringify!($Atomic), "`] and
 [`Cell<", stringify!($T), ">`](Cell), providing a consistent
 interface for interacting with the two types."),
+            #[deprecated(since = "0.2", note = "Use `Radium<T>` instead")]
             pub trait $Radium {
                 trait_decl!(int: $T, stringify!($Atomic));
             }
         }
 
+        #[allow(deprecated)]
         impl $Radium for $Atomic {
             atomic_impl!(int: $T);
         }
 
+        #[allow(deprecated)]
         impl $Radium for Cell<$T> {
             cell_impl!(int: $T);
         }
@@ -480,14 +490,17 @@ radium_int!(RadiumUsize, AtomicUsize, usize);
 ///
 /// This trait is implemented by both [`AtomicBool`] and [`Cell<bool>`](Cell),
 /// providing a consistent interface for interacting with the two types.
+#[deprecated(since = "0.2", note = "Prefer `Radium<bool>` instead")]
 pub trait RadiumBool {
     trait_decl!(binary: bool, "AtomicBool");
 }
 
+#[allow(deprecated)]
 impl RadiumBool for AtomicBool {
     atomic_impl!(binary: bool);
 }
 
+#[allow(deprecated)]
 impl RadiumBool for Cell<bool> {
     cell_impl!(binary: bool);
 }
@@ -499,14 +512,465 @@ impl RadiumBool for Cell<bool> {
 /// with the two types.
 ///
 /// [`*mut T`]: https://doc.rust-lang.org/stable/std/primitive.pointer.html
+#[deprecated(since = "0.2", note = "Prefer `Radium<*mut T>` instead")]
 pub trait RadiumPtr<T> {
     trait_decl!(base: *mut T, "AtomicPtr");
 }
 
+#[allow(deprecated)]
 impl<T> RadiumPtr<T> for AtomicPtr<T> {
     atomic_impl!(base: *mut T);
 }
 
+#[allow(deprecated)]
 impl<T> RadiumPtr<T> for Cell<*mut T> {
     cell_impl!(base: *mut T);
 }
+
+/** A maybe-atomic shared mutable fundamental type `T`.
+
+This trait is implemented by both the [atomic wrapper] type for `T`, and by
+[`Cell<T>`], providing a consistent interface for interacting with the two
+types.
+
+This trait only provides atomic load/store access, and does not perform
+type-specific operations on the values. For types that can be used in bitwise
+arithmetic, see [`RadiumBits`]; for types that can be used in integer
+arithmetic, see [`RadiumMath`].
+
+[atomic wrapper]: core::sync::atomic
+[`Cell<T>`]: core::cell::Cell
+[`RadiumBits`]: crate::RadiumBits
+[`RadiumMath`]: crate::RadiumMath
+**/
+pub trait Radium<Item> {
+    /// Creates a new value of this type.
+    fn new(value: Item) -> Self;
+
+    /// If the underlying value is atomic, calls [`fence`] with the given
+    /// [`Ordering`]. Otherwise, does nothing.
+    ///
+    /// [`Ordering`]: core::sync::atomic::Ordering
+    /// [`fence`]: core::sync::atomic::fence
+    fn fence(order: Ordering);
+
+    /// Returns a mutable reference to the underlying value.
+    ///
+    /// This is safe because the mutable reference to `self` guarantees that no
+    /// other references exist to this value.
+    fn get_mut(&mut self) -> &mut Item;
+
+    /// Consumes the wrapper and returns the contained value.
+    ///
+    /// This is safe as passing by value ensures no other references exist.
+    fn into_inner(self) -> Item;
+
+    /// Load a value from this object.
+    ///
+    /// Ordering values are ignored by non-atomic types.
+    ///
+    /// See also: [`AtomicU8::load`].
+    ///
+    /// [`AtomicU8::load`]: core::sync::atomic::AtomicU8::load
+    fn load(&self, order: Ordering) -> Item;
+
+    /// Store a value in this object.
+    ///
+    /// Ordering arguments are ignored by non-atomic types.
+    ///
+    /// See also: [`AtomicU8::store`]: core::sync::atomic::AtomicU8::store
+    fn store(&self, value: Item, order: Ordering);
+
+    /// Swap with the value stored in this object.
+    ///
+    /// Ordering arguments are ignored by non-atomic types.
+    ///
+    /// See also: [`AtomicU8::swap`].
+    ///
+    /// [`AtomicU8::swap`]: core::sync::atomic::AtomicU8::swap
+    fn swap(&self, value: Item, order: Ordering) -> Item;
+
+    /// Stores a value into this object if the currently-stored value is the
+    /// same as the `current` value.
+    ///
+    /// The return value is always the previously-stored value. If it is equal to
+    /// `current`, then the value was updated with `new`.
+    ///
+    /// Ordering arguments are ignored by non-atomic types.
+    ///
+    /// See also: [`AtomicU8::compare_and_swap`].
+    ///
+    /// [`AtomicU8::compare_and_swap`]: core::sync::atomic::AtomicU8::compare_and_swap
+    fn compare_and_swap(
+        &self,
+        current: Item,
+        new: Item,
+        order: Ordering,
+    ) -> Item;
+
+    /// Stores a value into this object if the currently-stored value is the
+    /// same as the `current` value.
+    ///
+    /// The return value is a `Result` indicating whether the new value was
+    /// written, and containing the previously-stored value. On success, this
+    /// value is guaranteed to be equal to `current`.
+    ///
+    /// Ordering arguments are ignored by non-atomic types.
+    ///
+    /// See also: [`AtomicU8::compare_exchange`].
+    ///
+    /// [`AtomicU8::compare_exchange`]: core::sync::atomic::AtomicU8::compare_exchange
+    fn compare_exchange(
+        &self,
+        current: Item,
+        new: Item,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<Item, Item>;
+
+    /// Stores a value into this object if the currently-stored value is the
+    /// same as the `current` value.
+    ///
+    /// Unlike `compare_exchange`, this function is allowed to spuriously fail
+    /// even when the comparison succeeds, which can result in more efficient
+    /// code on some platforms. The return value is a `Result` indicating
+    /// whether the new value was written, and containing the previously-stored
+    /// value.
+    ///
+    /// Ordering arguments are ignored by non-atomic types.
+    ///
+    /// See also: [`AtomicU8::compare_exchange_weak`].
+    ///
+    /// [`AtomicU8::compare_exchange_weak`]: core::sync::atomic::AtomicU8::compare_exchange_weak
+    fn compare_exchange_weak(
+        &self,
+        current: Item,
+        new: Item,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<Item, Item>;
+}
+
+/// Performs bitwise arithmetic on a maybe-atomic value.
+pub trait RadiumBits<Item>: Radium<Item> {
+    /// Performs a bitwise "and" on the currently-stored value and the argument
+    /// `value`, and stores the result in `self`.
+    ///
+    /// Returns the previously-stored value.
+    ///
+    /// Ordering arguments are ignored by non-atomic types.
+    ///
+    /// See also: [`AtomicU8::fetch_and`].
+    ///
+    /// [`AtomicU8::fetch_and`]: core::sync::atomic::AtomicU8::fetch_and
+    fn fetch_and(&self, value: Item, order: Ordering) -> Item;
+
+    /// Performs a bitwise "nand" on the currently-stored value and the argument
+    /// `value`, and stores the result in `self`.
+    ///
+    /// Returns the previously-stored value.
+    ///
+    /// Ordering arguments are ignored by non-atomic types.
+    ///
+    /// See also: [`AtomicU8::fetch_nand`].
+    ///
+    /// [`AtomicU8::fetch_nand`]: core::sync::atomic::AtomicU8::fetch_nand
+    fn fetch_nand(&self, value: Item, order: Ordering) -> Item;
+
+    /// Performs a bitwise "or" on the currently-stored value and the argument
+    /// `value`, and stores the result in `self`.
+    ///
+    /// Returns the previously-stored value.
+    ///
+    /// Ordering arguments are ignored by non-atomic types.
+    ///
+    /// See also: [`AtomicU8::fetch_or`].
+    ///
+    /// [`AtomicU8::fetch_or`]: core::sync::atomic::AtomicU8::fetch_or
+    fn fetch_or(&self, value: Item, order: Ordering) -> Item;
+
+    /// Performs a bitwise "xor" on the currently-stored value and the argument
+    /// `value`, and stores the result in `self`.
+    ///
+    /// Returns the previously-stored value.
+    ///
+    /// Ordering arguments are ignored by non-atomic types.
+    ///
+    /// See also: [`AtomicU8::fetch_xor`].
+    ///
+    /// [`AtomicU8::fetch_xor`]: core::sync::atomic::AtomicU8::fetch_xor
+    fn fetch_xor(&self, value: Item, order: Ordering) -> Item;
+}
+
+/// Performs integer arithmetic on a maybe-atomic value.
+pub trait RadiumMath<Item>: Radium<Item> {
+    /// Adds `value` to the currently-stored value, wrapping on overflow, and
+    /// stores the result in `self`.
+    ///
+    /// Returns the previously-stored value.
+    ///
+    /// Ordering arguments are ignored by non-atomic types.
+    ///
+    /// See also: [`AtomicU8::fetch_add`].
+    ///
+    /// [`AtomicU8::fetch_add`]: core::sync::atomic::AtomicU8::fetch_add
+    fn fetch_add(&self, value: Item, order: Ordering) -> Item;
+
+    /// Subtracts `value` from the currently-stored value, wrapping on
+    /// underflow, and stores the result in `self`.
+    ///
+    /// Returns the previously-stored value.
+    ///
+    /// Ordering arguments are ignored by non-atomic types.
+    ///
+    /// See also: [`AtomicU8::fetch_sub`].
+    ///
+    /// [`AtomicU8::fetch_sub`]: core::sync::atomic::AtomicU8::fetch_sub
+    fn fetch_sub(&self, value: Item, order: Ordering) -> Item;
+}
+
+macro_rules! radium {
+    ( atom $base:ty, $atom:ty ) => {
+
+        fn new(value: $base) -> Self {
+            <$atom>::new(value)
+        }
+
+        fn fence(order: Ordering) {
+            atomic::fence(order);
+        }
+
+        fn get_mut(&mut self) -> &mut $base {
+            self.get_mut()
+        }
+
+        fn into_inner(self) -> $base {
+            self.into_inner()
+        }
+
+        fn load(&self, order: Ordering) -> $base {
+            self.load(order)
+        }
+
+        fn store(&self, value: $base, order: Ordering) {
+            self.store(value, order);
+        }
+
+        fn swap(&self, value: $base, order: Ordering) -> $base {
+            self.swap(value, order)
+        }
+
+        fn compare_and_swap(
+            &self,
+            current: $base,
+            new: $base,
+            order: Ordering,
+        ) -> $base {
+            self.compare_and_swap(current, new, order)
+        }
+
+        fn compare_exchange(
+            &self,
+            current: $base,
+            new: $base,
+            success: Ordering,
+            failure: Ordering,
+        ) -> Result<$base, $base> {
+            self.compare_exchange(current, new, success, failure)
+        }
+
+        fn compare_exchange_weak(
+            &self,
+            current: $base,
+            new: $base,
+            success: Ordering,
+            failure: Ordering,
+        ) -> Result<$base, $base> {
+            self.compare_exchange_weak(current, new, success, failure)
+        }
+
+    };
+
+    ( atom_bits $base:ty, $atom:ty ) => {
+        fn fetch_and(&self, value: $base, order: Ordering) -> $base {
+            self.fetch_and(value, order)
+        }
+
+        fn fetch_nand(&self, value: $base, order: Ordering) -> $base {
+            self.fetch_nand(value, order)
+        }
+
+        fn fetch_or(&self, value: $base, order: Ordering) -> $base {
+            self.fetch_or(value, order)
+        }
+
+        fn fetch_xor(&self, value: $base, order: Ordering) -> $base {
+            self.fetch_xor(value, order)
+        }
+    };
+
+    ( atom_math $base:ty, $atom:ty ) => {
+        fn fetch_add(&self, value: $base, order: Ordering) -> $base {
+            self.fetch_add(value, order)
+        }
+
+        fn fetch_sub(&self, value: $base, order: Ordering) -> $base {
+            self.fetch_sub(value, order)
+        }
+    };
+
+    ( bits $( $base:ty , $atom:ty );* ) => { $(
+        impl Radium<$base> for $atom {
+            radium!(atom $base, $atom);
+        }
+
+        impl Radium<$base> for Cell<$base> {
+            radium!(cell $base);
+        }
+
+        impl RadiumBits<$base> for $atom {
+            radium!(atom_bits $base, $atom);
+        }
+
+        impl RadiumBits<$base> for Cell<$base> {
+            radium!(cell_bits $base);
+        }
+    )* };
+
+    ( cell $base:ty ) => {
+
+        fn new(value: $base) -> Self {
+            Cell::new(value)
+        }
+
+        fn fence(_: Ordering) {}
+
+        fn get_mut(&mut self) -> &mut $base {
+            self.get_mut()
+        }
+
+        fn into_inner(self) -> $base {
+            self.into_inner()
+        }
+
+        fn load(&self, _: Ordering) -> $base {
+            self.get()
+        }
+
+        fn store(&self, value: $base, _: Ordering) {
+            self.set(value);
+        }
+
+        fn swap(&self, value: $base, _: Ordering) -> $base {
+            self.replace(value)
+        }
+
+        fn compare_and_swap(
+            &self,
+            current: $base,
+            new: $base,
+            _: Ordering,
+        ) -> $base {
+            if self.get() == current {
+                self.replace(new)
+            }
+            else {
+                self.get()
+            }
+        }
+
+        fn compare_exchange(
+            &self,
+            current: $base,
+            new: $base,
+            _: Ordering,
+            _: Ordering,
+        ) -> Result<$base, $base> {
+            if self.get() == current {
+                Ok(self.replace(new))
+            }
+            else {
+                Err(self.get())
+            }
+        }
+
+        fn compare_exchange_weak(
+            &self,
+            current: $base,
+            new: $base,
+            success: Ordering,
+            failure: Ordering,
+        ) -> Result<$base, $base> {
+            Radium::compare_exchange(self, current, new, success, failure)
+        }
+
+    };
+
+    ( cell_bits $base:ty ) => {
+        fn fetch_and(&self, value: $base, _: Ordering) -> $base {
+            self.replace(self.get() & value)
+        }
+
+        fn fetch_nand(&self, value: $base, _: Ordering) -> $base {
+            self.replace(!(self.get() & value))
+        }
+
+        fn fetch_or(&self, value: $base, _: Ordering) -> $base {
+            self.replace(self.get() | value)
+        }
+
+        fn fetch_xor(&self, value: $base, _: Ordering) -> $base {
+            self.replace(self.get() ^ value)
+        }
+    };
+
+    ( cell_math $base:ty ) => {
+        fn fetch_add(&self, value: $base, _: Ordering) -> $base {
+            self.replace(self.get().wrapping_add(value))
+        }
+
+        fn fetch_sub(&self, value: $base, _: Ordering) -> $base {
+            self.replace(self.get().wrapping_sub(value))
+        }
+    };
+
+    ( num $( $base:ty , $atom:ty ; )* ) => { $(
+        radium!(bits $base, $atom);
+
+        impl RadiumMath<$base> for $atom {
+            radium!(atom_math $base, $atom);
+        }
+
+        impl RadiumMath<$base> for Cell<$base> {
+            radium!(cell_math $base);
+        }
+        )* };
+
+    ( ptr ) => {
+        impl<T> Radium<*mut T> for AtomicPtr<T> {
+            radium!(atom *mut T, AtomicPtr<T>);
+        }
+
+        impl<T> Radium<*mut T> for Cell<*mut T> {
+            radium!(cell *mut T);
+        }
+    };
+}
+
+radium![
+    num
+    i8, AtomicI8;
+    i16, AtomicI16;
+    i32, AtomicI32;
+    i64, AtomicI64;
+    isize, AtomicIsize;
+    u8, AtomicU8;
+    u16, AtomicU16;
+    u32, AtomicU32;
+    u64, AtomicU64;
+    usize, AtomicUsize;
+];
+
+radium!(bits bool, AtomicBool);
+
+radium!(ptr);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,9 +45,9 @@ use core::sync::atomic::{
 ///
 /// [atomic wrapper]: core::sync::atomic
 /// [`Cell<T>`]: core::cell::Cell
-pub trait Radium<Item> {
+pub trait Radium<T> {
     /// Creates a new value of this type.
-    fn new(value: Item) -> Self;
+    fn new(value: T) -> Self;
 
     /// If the underlying value is atomic, calls [`fence`] with the given
     /// [`Ordering`]. Otherwise, does nothing.
@@ -60,12 +60,12 @@ pub trait Radium<Item> {
     ///
     /// This is safe because the mutable reference to `self` guarantees that no
     /// other references exist to this value.
-    fn get_mut(&mut self) -> &mut Item;
+    fn get_mut(&mut self) -> &mut T;
 
     /// Consumes the wrapper and returns the contained value.
     ///
     /// This is safe as passing by value ensures no other references exist.
-    fn into_inner(self) -> Item;
+    fn into_inner(self) -> T;
 
     /// Load a value from this object.
     ///
@@ -74,7 +74,7 @@ pub trait Radium<Item> {
     /// See also: [`AtomicUsize::load`].
     ///
     /// [`AtomicUsize::load`]: core::sync::atomic::AtomicUsize::load
-    fn load(&self, order: Ordering) -> Item;
+    fn load(&self, order: Ordering) -> T;
 
     /// Store a value in this object.
     ///
@@ -83,7 +83,7 @@ pub trait Radium<Item> {
     /// See also: [`AtomicUsize::store`].
     ///
     /// [`AtomicUsize::store`]: core::sync::atomic::AtomicUsize::store
-    fn store(&self, value: Item, order: Ordering);
+    fn store(&self, value: T, order: Ordering);
 
     /// Swap with the value stored in this object.
     ///
@@ -92,7 +92,7 @@ pub trait Radium<Item> {
     /// See also: [`AtomicUsize::swap`].
     ///
     /// [`AtomicUsize::swap`]: core::sync::atomic::AtomicUsize::swap
-    fn swap(&self, value: Item, order: Ordering) -> Item;
+    fn swap(&self, value: T, order: Ordering) -> T;
 
     /// Stores a value into this object if the currently-stored value is the
     /// same as the `current` value.
@@ -105,7 +105,7 @@ pub trait Radium<Item> {
     /// See also: [`AtomicUsize::compare_and_swap`].
     ///
     /// [`AtomicUsize::compare_and_swap`]: core::sync::atomic::AtomicUsize::compare_and_swap
-    fn compare_and_swap(&self, current: Item, new: Item, order: Ordering) -> Item;
+    fn compare_and_swap(&self, current: T, new: T, order: Ordering) -> T;
 
     /// Stores a value into this object if the currently-stored value is the
     /// same as the `current` value.
@@ -121,11 +121,11 @@ pub trait Radium<Item> {
     /// [`AtomicUsize::compare_exchange`]: core::sync::atomic::AtomicUsize::compare_exchange
     fn compare_exchange(
         &self,
-        current: Item,
-        new: Item,
+        current: T,
+        new: T,
         success: Ordering,
         failure: Ordering,
-    ) -> Result<Item, Item>;
+    ) -> Result<T, T>;
 
     /// Stores a value into this object if the currently-stored value is the
     /// same as the `current` value.
@@ -143,11 +143,11 @@ pub trait Radium<Item> {
     /// [`AtomicUsize::compare_exchange_weak`]: core::sync::atomic::AtomicUsize::compare_exchange_weak
     fn compare_exchange_weak(
         &self,
-        current: Item,
-        new: Item,
+        current: T,
+        new: T,
         success: Ordering,
         failure: Ordering,
-    ) -> Result<Item, Item>;
+    ) -> Result<T, T>;
 
     /// Performs a bitwise "and" on the currently-stored value and the argument
     /// `value`, and stores the result in `self`.
@@ -159,9 +159,9 @@ pub trait Radium<Item> {
     /// See also: [`AtomicUsize::fetch_and`].
     ///
     /// [`AtomicUsize::fetch_and`]: core::sync::atomic::AtomicUsize::fetch_and
-    fn fetch_and(&self, value: Item, order: Ordering) -> Item
+    fn fetch_and(&self, value: T, order: Ordering) -> T
     where
-        Item: IsBits;
+        T: IsBits;
 
     /// Performs a bitwise "nand" on the currently-stored value and the argument
     /// `value`, and stores the result in `self`.
@@ -173,9 +173,9 @@ pub trait Radium<Item> {
     /// See also: [`AtomicUsize::fetch_nand`].
     ///
     /// [`AtomicUsize::fetch_nand`]: core::sync::atomic::AtomicUsize::fetch_nand
-    fn fetch_nand(&self, value: Item, order: Ordering) -> Item
+    fn fetch_nand(&self, value: T, order: Ordering) -> T
     where
-        Item: IsBits;
+        T: IsBits;
 
     /// Performs a bitwise "or" on the currently-stored value and the argument
     /// `value`, and stores the result in `self`.
@@ -187,9 +187,9 @@ pub trait Radium<Item> {
     /// See also: [`AtomicUsize::fetch_or`].
     ///
     /// [`AtomicUsize::fetch_or`]: core::sync::atomic::AtomicUsize::fetch_or
-    fn fetch_or(&self, value: Item, order: Ordering) -> Item
+    fn fetch_or(&self, value: T, order: Ordering) -> T
     where
-        Item: IsBits;
+        T: IsBits;
 
     /// Performs a bitwise "xor" on the currently-stored value and the argument
     /// `value`, and stores the result in `self`.
@@ -201,9 +201,9 @@ pub trait Radium<Item> {
     /// See also: [`AtomicUsize::fetch_xor`].
     ///
     /// [`AtomicUsize::fetch_xor`]: core::sync::atomic::AtomicUsize::fetch_xor
-    fn fetch_xor(&self, value: Item, order: Ordering) -> Item
+    fn fetch_xor(&self, value: T, order: Ordering) -> T
     where
-        Item: IsBits;
+        T: IsBits;
 
     /// Adds `value` to the currently-stored value, wrapping on overflow, and
     /// stores the result in `self`.
@@ -215,9 +215,9 @@ pub trait Radium<Item> {
     /// See also: [`AtomicUsize::fetch_add`].
     ///
     /// [`AtomicUsize::fetch_add`]: core::sync::atomic::AtomicUsize::fetch_add
-    fn fetch_add(&self, value: Item, order: Ordering) -> Item
+    fn fetch_add(&self, value: T, order: Ordering) -> T
     where
-        Item: IsANum;
+        T: IsANum;
 
     /// Subtracts `value` from the currently-stored value, wrapping on
     /// underflow, and stores the result in `self`.
@@ -229,9 +229,9 @@ pub trait Radium<Item> {
     /// See also: [`AtomicUsize::fetch_sub`].
     ///
     /// [`AtomicUsize::fetch_sub`]: core::sync::atomic::AtomicUsize::fetch_sub
-    fn fetch_sub(&self, value: Item, order: Ordering) -> Item
+    fn fetch_sub(&self, value: T, order: Ordering) -> T
     where
-        Item: IsANum;
+        T: IsANum;
 }
 
 /// Marks that a type can be viewed as a set of bits.
@@ -239,9 +239,8 @@ pub trait Radium<Item> {
 /// `bool` and all integer fundamentals implement this.
 ///
 /// ```rust
-/// use core::sync::atomic::*;
-/// use radium::Radium;
-///
+/// # use core::sync::atomic::*;
+/// # use radium::Radium;
 /// let num: AtomicUsize = AtomicUsize::new(0);
 /// Radium::fetch_or(&num, 2, Ordering::Relaxed);
 /// ```
@@ -252,8 +251,8 @@ pub trait Radium<Item> {
 /// # use core::sync::atomic::*;
 /// # use radium::Radium;
 /// let mut data = 0usize;
-/// let ptr: AtomicPtr<usize> = AtomicPtr::new(&data as *mut usize);
-/// Radium::fetch_or(&ptr, &data as *mut usize, Ordering::Relaxed);
+/// let ptr: AtomicPtr<usize> = AtomicPtr::new(Default::default());
+/// Radium::fetch_or(&ptr, &mut data as *mut usize, Ordering::Relaxed);
 /// ```
 pub trait IsBits {}
 
@@ -262,9 +261,8 @@ pub trait IsBits {}
 /// All integer fundamentals implement this.
 ///
 /// ```rust
-/// use core::sync::atomic::*;
-/// use radium::Radium;
-///
+/// # use core::sync::atomic::*;
+/// # use radium::Radium;
 /// let num: AtomicUsize = AtomicUsize::new(2);
 /// Radium::fetch_and(&num, 2, Ordering::Relaxed);
 /// ```


### PR DESCRIPTION
This change allows `radium` to be used in type-generic contexts. Because Rust does not have a way to express "type `T` must implement one of this list of traits", only "type `T` must implement all of this list of traits", the discrete `RadiumType` traits cannot be used in generic code.

A generic `Radium` trait (and `RadiumBits` and `RadiumInteger`) allows code such as this:

```rust
pub struct Counter<T, R: RadiumInteger<T>> {
  inner: R,
}

let atom: Counter<u8, AtomicU8>;
let cell: Counter<u8, Cell<u8>>;
```

to be made generic over the integer primitive types as well as the atomicity of their access.