### PR TITLE
Gate the 64-bit types on 64-bit targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radium"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
     "Nika Layzell <nika@thelayzells.com>",
     "myrrlyn <self@myrrlyn.dev>"

--- a/examples/schroedinger.rs
+++ b/examples/schroedinger.rs
@@ -10,13 +10,13 @@ use radium::Radium;
 
 use std::{
     cell::Cell,
-    sync::atomic::{AtomicU64, Ordering},
+    sync::atomic::{AtomicU32, Ordering},
     thread,
     time::Duration,
 };
 
 /// Operates on a value, which might or might not be atomic.
-fn routine<R: Radium<u64>>(obj: &R, ident: usize) {
+fn routine<R: Radium<u32>>(obj: &R, ident: usize) {
     println!(
         "Entry {} observes value: {}",
         ident,
@@ -29,7 +29,9 @@ fn routine<R: Radium<u64>>(obj: &R, ident: usize) {
         ident,
         obj.load(Ordering::Relaxed)
     );
-    thread::sleep(Duration::from_millis(obj.load(Ordering::Relaxed) * 10));
+    thread::sleep(Duration::from_millis(
+        obj.load(Ordering::Relaxed) as u64 * 10,
+    ));
     let subbed = obj.fetch_sub(1, Ordering::Relaxed);
     println!("Exit {} observes fetched value: {}", ident, subbed);
     println!(
@@ -40,12 +42,12 @@ fn routine<R: Radium<u64>>(obj: &R, ident: usize) {
 }
 
 /// Single value which will be contended by multiple threads
-static HOT: AtomicU64 = AtomicU64::new(0);
+static HOT: AtomicU32 = AtomicU32::new(0);
 
 fn main() {
     //  This cannot cross a thread, so it is only accessed without contention in
     //  an ordered call sequence.
-    let cold = Cell::new(0u64);
+    let cold = Cell::new(0u32);
 
     routine(&cold, 0);
     let one = thread::spawn(move || {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,9 +26,17 @@
 
 use core::cell::Cell;
 use core::sync::atomic::{
-    self, AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize, AtomicPtr, AtomicU16,
-    AtomicU32, AtomicU64, AtomicU8, AtomicUsize, Ordering,
+    self, AtomicBool, AtomicI16, AtomicI32, AtomicI8, AtomicIsize, AtomicPtr, AtomicU16, AtomicU32,
+    AtomicU8, AtomicUsize, Ordering,
 };
+
+// Note: The correct gate to use is `target_has_atomic`, but it is unstable as
+// of EOY 2019, and cannot be used in libraries targeting stable. When this
+// attribute stabilizes, all types from i8 through i128 should be separately
+// gated on this attribute, in order to match the standard library's provision
+// of atomic types.
+#[cfg(target_pointer_width = "64")]
+use core::sync::atomic::{AtomicI64, AtomicU64};
 
 /// A maybe-atomic shared mutable fundamental type `T`.
 ///
@@ -537,13 +545,18 @@ radium![
     i8, AtomicI8;
     i16, AtomicI16;
     i32, AtomicI32;
-    i64, AtomicI64;
     isize, AtomicIsize;
     u8, AtomicU8;
     u16, AtomicU16;
     u32, AtomicU32;
-    u64, AtomicU64;
     usize, AtomicUsize;
+];
+
+#[cfg(target_pointer_width = "64")]
+radium![
+    int
+    i64, AtomicI64;
+    u64, AtomicU64;
 ];
 
 impl marker::BitOps for bool {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,8 @@ use core::sync::atomic::{
 // attribute stabilizes, all types from i8 through i128 should be separately
 // gated on this attribute, in order to match the standard library's provision
 // of atomic types.
+//
+// Rust tracking issue: https://github.com/rust-lang/rust/issues/32976
 #[cfg(target_pointer_width = "64")]
 use core::sync::atomic::{AtomicI64, AtomicU64};
 


### PR DESCRIPTION
The standard library appears to not provide 64-bit atomic types on
32-bit targets, so `radium` does not compile on 32-bit targets without
removal of those now-non-existent type names.

----

The issue report [myrrlyn/bitvec#36](https://github.com/myrrlyn/bitvec/issues/36) indicates that the `Atomic{I,U}64` type names do not exist on the `thumbv7-none-eabi` target, and possibly other 32-bit architectures. The standard library's granular existence gates are not available to us, so this patch uses `target_pointer_width` until the standard library stabilizes its gates.