### PR TITLE
Add thumbv8m.main target

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -77,7 +77,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // both `target_arch = "riscv32", and have no stable `cfg`-discoverable
         // distinction. As such, the atomic RISC-V target must be discovered
         // here.
-        "armv5te" | "mips" | "mipsel" | "powerpc" | "riscv32imac" | "thumbv7em" | "thumbv7m" => {
+        "armv5te" | "mips" | "mipsel" | "powerpc" | "riscv32imac" | "thumbv7em" | "thumbv7m" | "thumbv8m.main" => {
             atomics.has_64 = false
         }
         "riscv32i" | "riscv32imc" | "thumbv6m" => atomics = Atomics::NONE,


### PR DESCRIPTION
ARMv8m has 32-bit atomics. Note there is also a thumbv8m.base target which can be added separately.