### PR TITLE
Use `cfg(target_has_atomic)` instead of buildscript

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,69 +1,69 @@
 #[doc(hidden)]
 #[macro_export]
-#[cfg(radium_atomic_8)]
+#[cfg(target_has_atomic = "8")]
 macro_rules! __radium_if_atomic_8 {
     ( [ $( $a:tt )* ] [ $( $b:tt )* ] ) => { $($a)* }
 }
 
 #[doc(hidden)]
 #[macro_export]
-#[cfg(not(radium_atomic_8))]
+#[cfg(not(target_has_atomic = "8"))]
 macro_rules! __radium_if_atomic_8 {
     ( [ $( $a:tt )* ] [ $( $b:tt )* ] ) => { $($b)* }
 }
 
 #[doc(hidden)]
 #[macro_export]
-#[cfg(radium_atomic_16)]
+#[cfg(target_has_atomic = "16")]
 macro_rules! __radium_if_atomic_16 {
     ( [ $( $a:tt )* ] [ $( $b:tt )* ] ) => { $($a)* }
 }
 
 #[doc(hidden)]
 #[macro_export]
-#[cfg(not(radium_atomic_16))]
+#[cfg(not(target_has_atomic = "16"))]
 macro_rules! __radium_if_atomic_16 {
     ( [ $( $a:tt )* ] [ $( $b:tt )* ] ) => { $($b)* }
 }
 
 #[doc(hidden)]
 #[macro_export]
-#[cfg(radium_atomic_32)]
+#[cfg(target_has_atomic = "32")]
 macro_rules! __radium_if_atomic_32 {
     ( [ $( $a:tt )* ] [ $( $b:tt )* ] ) => { $($a)* }
 }
 
 #[doc(hidden)]
 #[macro_export]
-#[cfg(not(radium_atomic_32))]
+#[cfg(not(target_has_atomic = "32"))]
 macro_rules! __radium_if_atomic_32 {
     ( [ $( $a:tt )* ] [ $( $b:tt )* ] ) => { $($b)* }
 }
 
 #[doc(hidden)]
 #[macro_export]
-#[cfg(radium_atomic_64)]
+#[cfg(target_has_atomic = "64")]
 macro_rules! __radium_if_atomic_64 {
     ( [ $( $a:tt )* ] [ $( $b:tt )* ] ) => { $($a)* }
 }
 
 #[doc(hidden)]
 #[macro_export]
-#[cfg(not(radium_atomic_64))]
+#[cfg(not(target_has_atomic = "64"))]
 macro_rules! __radium_if_atomic_64 {
     ( [ $( $a:tt )* ] [ $( $b:tt )* ] ) => { $($b)* }
 }
 
 #[doc(hidden)]
 #[macro_export]
-#[cfg(radium_atomic_ptr)]
+#[cfg(target_has_atomic = "ptr")]
 macro_rules! __radium_if_atomic_ptr {
     ( [ $( $a:tt )* ] [ $( $b:tt )* ] ) => { $($a)* }
 }
 
 #[doc(hidden)]
 #[macro_export]
-#[cfg(not(radium_atomic_ptr))]
+#[cfg(not(target_has_atomic = "ptr"))]
 macro_rules! __radium_if_atomic_ptr {
     ( [ $( $a:tt )* ] [ $( $b:tt )* ] ) => { $($b)* }
 }


### PR DESCRIPTION
There are currently three atomic cfg gates rustc provides:

| | |
| - | - |
| stable | `cfg(target_has_atomic)` |
| unstable | `cfg(target_has_atomic_load_store)` |
| unstable | `cfg(target_has_atomic_equal_alignment)` |

`target_has_atomic_load_store` *actually* gates the presence of `AtomicNN`. `target_has_atomic` is set by atomic swap presence and gates most methods. `target_has_atomic_equal_alignment` gates `from_mut` methods.

The API that the `Radium` trait provides lines up exactly with `cfg(target_has_atomic)`; `Radium` requires swapping but not `from_mut`.

-----

Closes #13; this is a conflict-resolved separately derived version of that PR.

If we want to keep the buildscript, then we can, but this `cfg` is documented to be exactly the gate that the buildscript is duplicating currently. At a minimum, I'd suggest making the `cfg` the default and only keeping an override list. (i.e. the full cfg would be `cfg(all(not(radium_force_no_atomic_N), any(target_has_atomic = "N", radium_force_has_atomic_N)))` (ordered for desired precedence).)

Does not bump version number yet[^1]. Per policy, this should be a minor release.

[^1]: There's a separate patch to add `{u,i}128` support coming that should also be merged first.