### PR TITLE
Add support for 128-bit integers

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -56,6 +56,20 @@ macro_rules! __radium_if_atomic_64 {
 
 #[doc(hidden)]
 #[macro_export]
+#[cfg(target_has_atomic = "128")]
+macro_rules! __radium_if_atomic_128 {
+    ( [ $( $a:tt )* ] [ $( $b:tt )* ] ) => { $($a)* }
+}
+
+#[doc(hidden)]
+#[macro_export]
+#[cfg(not(target_has_atomic = "128"))]
+macro_rules! __radium_if_atomic_128 {
+    ( [ $( $a:tt )* ] [ $( $b:tt )* ] ) => { $($b)* }
+}
+
+#[doc(hidden)]
+#[macro_export]
 #[cfg(radium_atomic_ptr)]
 macro_rules! __radium_if_atomic_ptr {
     ( [ $( $a:tt )* ] [ $( $b:tt )* ] ) => { $($a)* }
@@ -98,6 +112,7 @@ macro_rules! __radium_if_atomic_ptr {
 /// - `16`
 /// - `32`
 /// - `64`
+/// - `128`
 /// - `ptr`
 /// - `bool`: alias for `8`
 /// - `size`: alias for `ptr`
@@ -150,6 +165,13 @@ macro_rules! if_atomic {
 
     ( if atomic(64) { $($a:tt)* } $( else { $($b:tt)* } )? $( if $($rest:tt)* )? ) => {
         $crate::__radium_if_atomic_64! {
+            [ $($a)* ] [ $( $($b)* )? ]
+        }
+        $( $crate::if_atomic! { if $($rest)* } )?
+    };
+
+    ( if atomic(128) { $($a:tt)* } $( else { $($b:tt)* } )? $( if $($rest:tt)* )? ) => {
+        $crate::__radium_if_atomic_128! {
             [ $($a)* ] [ $( $($b)* )? ]
         }
         $( $crate::if_atomic! { if $($rest)* } )?

--- a/src/types.rs
+++ b/src/types.rs
@@ -59,6 +59,18 @@ pub type RadiumU64 = if_atomic! {
     else { core::cell::Cell<u64> }
 };
 
+/// Best-effort atomic `i128` type.
+pub type RadiumI128 = if_atomic! {
+    if atomic(128) { core::sync::atomic::AtomicI128 }
+    else { core::cell::Cell<i128> }
+};
+
+/// Best-effort atomic `u128` type.
+pub type RadiumU128 = if_atomic! {
+    if atomic(128) { core::sync::atomic::AtomicU128 }
+    else { core::cell::Cell<u128> }
+};
+
 /// Best-effort atomic `isize` type.
 pub type RadiumIsize = if_atomic! {
     if atomic(size) { core::sync::atomic::AtomicIsize }


### PR DESCRIPTION
Even if <=64bit stays on the buildscript, it imho makes sense to use cfg(target_has_atomic) for 128-bit atomics. The presence of 128bit atomics is much more esoteric, so we absolutely should delegate to the preexisting list which std already has to keep.